### PR TITLE
Fix issue 16

### DIFF
--- a/app/src/main/java/com/github/shadowsocks/plugin/v2ray/CertificatePreferenceDialogFragment.kt
+++ b/app/src/main/java/com/github/shadowsocks/plugin/v2ray/CertificatePreferenceDialogFragment.kt
@@ -39,7 +39,7 @@ class CertificatePreferenceDialogFragment : EditTextPreferenceDialogFragmentComp
             try {
                 targetFragment!!.startActivityForResult(Intent(Intent.ACTION_GET_CONTENT).apply {
                     addCategory(Intent.CATEGORY_OPENABLE)
-                    type = "application/pkix-cert"
+                    type = "application/x-pem-file"
                 }, ConfigFragment.REQUEST_BROWSE_CERTIFICATE)
                 return@setNeutralButton
             } catch (_: ActivityNotFoundException) { } catch (_: SecurityException) { }

--- a/app/src/main/java/com/github/shadowsocks/plugin/v2ray/ConfigFragment.kt
+++ b/app/src/main/java/com/github/shadowsocks/plugin/v2ray/ConfigFragment.kt
@@ -63,7 +63,7 @@ class ConfigFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChange
         putWithDefault("host", host.text, "cloudfront.com")
         putWithDefault("path", path.text, "/")
         putWithDefault("mux", mux.text, "1")
-        putWithDefault("certRaw", certRaw.text?.replace("\n", ""), "")
+        putWithDefault("certRaw", certRaw.text?.replace("\n", "\\n"), "")
         putWithDefault("loglevel", loglevel.value, "warning")
     }
 
@@ -76,7 +76,8 @@ class ConfigFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChange
         host.text = options["host"] ?: "cloudfront.com"
         path.text = options["path"] ?: "/"
         mux.text = options["mux"] ?: "1"
-        certRaw.text = options["certRaw"]
+        certRaw.text = options["certRaw"] ?: ""
+        certRaw.text = certRaw.text.replace("\\n", "\n")
         loglevel.value = options["loglevel"] ?: "warning"
     }
 
@@ -122,6 +123,7 @@ class ConfigFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChange
                     // we read all its content here to avoid content URL permission issues
                     certRaw.text = activity.contentResolver.openInputStream(data!!.data!!)!!
                             .bufferedReader().readText()
+
                 } catch (e: RuntimeException) {
                     Snackbar.make(activity.findViewById(R.id.content), e.localizedMessage ?: e.javaClass.name,
                             Snackbar.LENGTH_LONG).show()

--- a/app/src/main/java/com/github/shadowsocks/plugin/v2ray/ConfigFragment.kt
+++ b/app/src/main/java/com/github/shadowsocks/plugin/v2ray/ConfigFragment.kt
@@ -123,7 +123,6 @@ class ConfigFragment : PreferenceFragmentCompat(), Preference.OnPreferenceChange
                     // we read all its content here to avoid content URL permission issues
                     certRaw.text = activity.contentResolver.openInputStream(data!!.data!!)!!
                             .bufferedReader().readText()
-
                 } catch (e: RuntimeException) {
                     Snackbar.make(activity.findViewById(R.id.content), e.localizedMessage ?: e.javaClass.name,
                             Snackbar.LENGTH_LONG).show()


### PR DESCRIPTION
This is supposed to handle `\n` in PEM certificate, so that v2ray could correctly receive the right certificate content.

In addition, V2ray only accepts `certRaw` in PEM format, so it's necessary to change type to `application/x-pem-file`
