### PR TITLE
Update dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,8 +17,8 @@ android {
     defaultConfig {
         minSdk = 26
         targetSdk = 35
-        versionCode = 1030300
-        versionName = "1.3.3"
+        versionCode = 1030500
+        versionName = "1.3.5"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    val javaVersion = JavaVersion.VERSION_1_8
+    val javaVersion = JavaVersion.VERSION_17
     compileSdk = 35
     compileOptions {
         sourceCompatibility = javaVersion
@@ -15,11 +15,11 @@ android {
     kotlinOptions.jvmTarget = javaVersion.toString()
     namespace = "com.github.shadowsocks.plugin.v2ray"
     defaultConfig {
-        minSdk = 23
+        minSdk = 26
         targetSdk = 35
         versionCode = 1030300
         versionName = "1.3.3"
-        testInstrumentationRunner = "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
         getByName("release") {
@@ -37,6 +37,11 @@ android {
     sourceSets.getByName("main").jniLibs.srcDirs(files("$projectDir/build/go"))
     ndkVersion = "27.2.12479018"
     packagingOptions.jniLibs.useLegacyPackaging = true
+    externalNativeBuild {
+        ndkBuild {
+            ndkVersion = "27.2.12479018"
+        }
+    }
 }
 
 tasks.register<Exec>("goBuild") {
@@ -62,6 +67,6 @@ dependencies {
     implementation("com.github.shadowsocks:plugin:2.0.1")
     implementation("com.takisoft.preferencex:preferencex-simplemenu:1.1.0")
     testImplementation("junit:junit:4.13.2")
-    androidTestImplementation("androidx.test:runner:1.6.2")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
+    androidTestImplementation("androidx.test:runner:1.7.0")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.7.0")
 }

--- a/app/go-build.bash
+++ b/app/go-build.bash
@@ -20,6 +20,7 @@ for i in "${!ABIS[@]}"; do
     && env \
         CGO_ENABLED=1 CC="${TOOLCHAIN}/${CLANG_ARCHS[$i]}${MIN_API}-clang" \
         GOOS=android GOARCH=${GO_ARCHS[$i]} \
+        GOFLAGS="-mod=mod" \
         go build -v -ldflags='-s -w' -o "${OUT_DIR}/unstripped" \
     && "${TOOLCHAIN}/llvm-strip" "${OUT_DIR}/unstripped" -o "${OUT_DIR}/${ABI}/${BIN}" \
     || exit -1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.github.ben-manes.versions") version "0.51.0"
+    id("com.github.ben-manes.versions") version "0.52.0"
 }
 
 buildscript {
@@ -8,7 +8,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:8.7.2")
+        classpath("com.android.tools.build:gradle:8.9.0")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.0.21")
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,6 @@
 # The setting is particularly useful for tweaking memory settings.
 android.enableJetifier=true
 android.enableR8.fullMode=true
-android.enableResourceOptimizations=false
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 # When configured, Gradle will run in incubating parallel mode.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- Upgrade Android Gradle Plugin: 8.7.2 → 8.9.0
- Upgrade Kotlin Gradle Plugin: 2.0.21 → 2.0.21 (compatible)
- Upgrade Gradle wrapper: 8.10.2 → 8.11.1
- Upgrade AndroidX Test Runner: 1.6.2 → 1.7.0
- Upgrade AndroidX Espresso Core: 3.6.1 → 3.7.0
- Upgrade Java version: 1.8 → 17
- Increase minSdk: 23 → 26 (Android 8.0+)
- Update test runner to use androidx instead of deprecated android.support
- Remove deprecated gradle property android.enableResourceOptimizations
- Update v2ray-plugin to v5.44.1 with latest dependencies
- Fix Go protobuf compatibility with replace directive
- Update go-build.bash to support GOFLAGS for module management
- Update v2ray-plugin main.go to use github.com/golang/protobuf for compatibility

--------------

Verison bump to 1.3.5

pls test @Mygod and see if it works for you